### PR TITLE
Correct Spelling and add output option

### DIFF
--- a/hash/hash.html
+++ b/hash/hash.html
@@ -4,7 +4,8 @@ RED.nodes.registerType( 'hash', {
   color: '#a6bbcf',
   defaults: {
     name: { value: '' },
-    algorhythm: { value: 'sha512' }
+    algorithm: { value: 'sha512' },
+    outPay: {value: true}
   },
   inputs: 1,
   outputs: 1,
@@ -18,10 +19,10 @@ RED.nodes.registerType( 'hash', {
 <script type="text/x-red" data-template-name="hash">
 <div class="form-row">
   <label for="node-input-name"><i class="icon-tag"></i> Name</label>
-  <input type="text" id="node-input-name" placeholder="Name">
+  <input type="text" id="node-input-name" placeholder="Name" />
   <br/>
-  <label for="node-input-algorhythm"><i class="icon-tag"></i> Algorhythm</label>
-  <select id="node-input-algorhythm">
+  <label for="node-input-algorithm"><i class="icon-tag"></i> algorithm</label>
+  <select id="node-input-algorithm">
   <option value="md1">MD1</option>
   <option value="md2">MD2</option>
   <option value="md5">MD5</option>
@@ -29,15 +30,18 @@ RED.nodes.registerType( 'hash', {
   <option value="sha256">SHA256</option>
   <option value="sha512" selected>SHA512</option>
   </select>
+  <br/>
+  <input type="checkbox" id="node-input-outPay" selected  />
+    <label for="node-input-outPay">Output the hash in msg.payload (as opposed to msg.hash)</label>
 </div>
 </script>
 
 <script type="text/x-red" data-help-name="hash">
-  <p>A simple node that calculate hashed value with specified algorhythm for payload.</p>
+  <p>A simple node that calculate hashed value with specified algorithm for payload.</p>
   <p><table border="1">
   <tr><td>Input</td><td>msg.payload</td><td>value which is to be hashed.</td></tr>
-  <tr><td>Input</td><td>msg.algorhythm</td><td>hash algorhythm(default sha512)</td></tr>
-  <tr><td>Output</td><td>msg.hash</td><td>hashed value.</td></tr>
+  <tr><td>Input</td><td>msg.algorithm</td><td>hash algorithm(default sha512)</td></tr>
+  <tr><td>Output</td><td>msg.payload (by default)</td><td>hashed value.</td></tr>
   </table></p>
 </script>
 

--- a/hash/hash.js
+++ b/hash/hash.js
@@ -18,7 +18,9 @@ module.exports = function( RED ){
       }
 
       hash.update( payload );
-      msg.hash = hash.digest( 'hex' );
+      if(config.outPay)
+        msg.payload = hash.digest( 'hex' );
+      else msg.hash = hash.digest( 'hex' );
       node.send( msg );
     });
   }

--- a/hash/hash.js
+++ b/hash/hash.js
@@ -4,17 +4,17 @@ module.exports = function( RED ){
   function HashNode( config ){
     RED.nodes.createNode( this, config );
 
-    this.algorhythm = config.algorhythm;
-    console.log( this.algorhythm );
-    var hash = crypto.createHash( this.algorhythm );
+    this.algorithm = config.algorithm;
+    console.log( this.algorithm );
+    var hash = crypto.createHash( this.algorithm );
 
     var node = this;
     node.on( 'input', function( msg ){
       var payload = msg.payload;
-      var algorhythm = msg.algorhythm;
-      if( algorhythm ){
-        console.log( algorhythm );
-        hash = crypto.createHash( algorhythm );
+      var algorithm = msg.algorithm;
+      if( algorithm ){
+        console.log( algorithm );
+        hash = crypto.createHash( algorithm );
       }
 
       hash.update( payload );


### PR DESCRIPTION
Changed "algorhythm" to "algorithm", and added the option to use msg.payload (default as it matches how most other simple transform nodes work) or msg.hash as the output.